### PR TITLE
Allow distance_thresholds parameter to be NULL, according to documentation

### DIFF
--- a/R/MK_dIICPC.R
+++ b/R/MK_dIICPC.R
@@ -108,10 +108,6 @@ MK_dPCIIC <- function(nodes, attribute  = NULL,
     }
   }
 
-  if (is.null(distance_thresholds)) {
-    stop("error missing numeric distance threshold(s)")
-  }
-
   if (!is.null(write)) {
     if (!dir.exists(dirname(write))) {
       stop("error, output folder does not exist")


### PR DESCRIPTION
About the `distance_thresholds` parameter of the function `MK_dIICPC`, the documentation says that:

    If NULL then the mean distance between nodes will be estimated and used

However there is a check at the beginning of the function which does not allow this parameter to be NULL, and further, there is an instruction meant to be executed when `distance_thresholds` is NULL:

      if(is.null(distance_thresholds)){
        distance_thresholds <- mean(dist)
      }

As this instruction is not accessible, I suggest removing the initial check.